### PR TITLE
fix: Consistent docker-flow for UnownHash projects

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,3 +12,4 @@ RUN cd server && go build -o Admin
 FROM golang:1.20.2-alpine3.17
 COPY --from=client /app/dist ./dist
 COPY --from=server /app/server/Admin Admin
+CMD ["./Admin"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,6 @@ services:
   admin:
     image: ghcr.io/unownhash/flygon-admin:main
     container_name: admin
-    command: './Admin'
     restart: unless-stopped
     environment:
       ADMIN_GENERAL_USERNAME: admin


### PR DESCRIPTION
Admin was the only project of the three not using `CMD` argument in the docker build. This aligns with FlyGOn & Golbat.

There are still some remaining inconsistencies between the projects but those are larger changes which I don't want to touch without knowing the final plan.

Compiles and runs on my system.

Fixes: https://github.com/UnownHash/Flygon/issues/4